### PR TITLE
Add readthedocs link to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ requires-python = ">= 3.9"
 "Source" = "https://github.com/dbfixtures/pytest-postgresql"
 "Bug Tracker" = "https://github.com/dbfixtures/pytest-postgresql/issues"
 "Changelog" = "https://github.com/dbfixtures/pytest-postgresql/blob/v7.0.0/CHANGES.rst"
+"Documentation" = "https://pytest-pgsql.readthedocs.io/en/latest/"
 
 [project.entry-points."pytest11"]
 pytest_postgresql = "pytest_postgresql.plugin"


### PR DESCRIPTION
There was no link anywhere that stood out to me, this should put it in the PyPi sidebar.

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number

-----

I'm... not a Python person, and couldn't find a link to readthedocs in an obvious place, but a quick search online seems to suggest this change should put the link in the sidebar on PyPi.

I have no clue what that chore thing is about, it seems to be from a template, I'm leaving it as is.