### PR TITLE
fixup: closing connection when load sql files

### DIFF
--- a/newsfragments/+8bf3ab6b.bugfix.rst
+++ b/newsfragments/+8bf3ab6b.bugfix.rst
@@ -1,0 +1,3 @@
+Close postgresql connection after loading sql files.
+
+Fixes possible `ResourceWarning`

--- a/pytest_postgresql/loader.py
+++ b/pytest_postgresql/loader.py
@@ -25,8 +25,8 @@ def build_loader(load: Union[Callable, str, Path]) -> Callable:
 
 def sql(sql_filename: Path, **kwargs: Any) -> None:
     """Database loader for sql files."""
-    db_connection = psycopg.connect(**kwargs)
-    with open(sql_filename, "r") as _fd:
-        with db_connection.cursor() as cur:
-            cur.execute(_fd.read())
-    db_connection.commit()
+    with psycopg.connect(**kwargs) as db_connection:
+        with open(sql_filename, "r") as _fd:
+            with db_connection.cursor() as cur:
+                cur.execute(_fd.read())
+        db_connection.commit()


### PR DESCRIPTION
while execute tests with load kwargs appears warnings:

> /usr/local/lib/python3.12/site-packages/psycopg/_connection_base.py:149: ResourceWarning: connection <psycopg.Connection [IDLE] (host=test user=test database=tests_tmpl) at 0x7f450fb451f0> was deleted while still open. Please use 'with' or '.close()' to close the connection
