### PR TITLE
Introduce FBT linter - closes #1387

### DIFF
--- a/newsfragments/1387.break.1.rst
+++ b/newsfragments/1387.break.1.rst
@@ -1,0 +1,2 @@
+Arguments after `dbname` in `postgresql_proc` are now keyword-only. Update callers that pass
+`options`, `startparams`, `unixsocketdir`, `postgres_options`, `load` or `load_autocommit` positionally.

--- a/newsfragments/1387.break.2.rst
+++ b/newsfragments/1387.break.2.rst
@@ -1,0 +1,2 @@
+Arguments after `dbname` in `postgresql_noproc` are now keyword-only. Update callers that pass
+`options`, `load`, `load_autocommit` or `depends_on` positionally.

--- a/newsfragments/1387.break.rst
+++ b/newsfragments/1387.break.rst
@@ -1,0 +1,3 @@
+Arguments after `dbname` in `PostgreSQLExecutor`. Update callers that pass
++`shell`, `timeout`, `sleep`, `user`, `password`,
++`options`, or `postgres_options` positionally.

--- a/newsfragments/1387.misc.rst
+++ b/newsfragments/1387.misc.rst
@@ -1,0 +1,1 @@
+Enabled Ruff's `FBT <https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt>`_ rules to detect boolean positional arguments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,10 +76,11 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E", # pycodestyle
-    "F", # pyflakes
-    "I", # isort
-    "D", # pydocstyle
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "D",   # pydocstyle
+    "FBT", # flake8-boolean-trap
 ]
 
 [tool.pyproject-fmt]

--- a/pytest_postgresql/executor.py
+++ b/pytest_postgresql/executor.py
@@ -99,6 +99,7 @@ class PostgreSQLExecutor(TCPExecutor):
         logfile: str,
         startparams: str,
         dbname: str,
+        *,
         shell: bool = False,
         timeout: Optional[int] = 60,
         sleep: float = 0.1,

--- a/pytest_postgresql/factories/noprocess.py
+++ b/pytest_postgresql/factories/noprocess.py
@@ -43,6 +43,7 @@ def postgresql_noproc(
     user: str | None = None,
     password: str | None = None,
     dbname: str | None = None,
+    *,
     options: str = "",
     load: list[Callable | str | Path] | None = None,
     load_autocommit: bool | None = None,

--- a/pytest_postgresql/factories/process.py
+++ b/pytest_postgresql/factories/process.py
@@ -89,6 +89,7 @@ def postgresql_proc(
     user: str | None = None,
     password: str | None = None,
     dbname: str | None = None,
+    *,
     options: str = "",
     startparams: str | None = None,
     unixsocketdir: str | None = None,

--- a/pytest_postgresql/janitor.py
+++ b/pytest_postgresql/janitor.py
@@ -296,7 +296,7 @@ class AsyncDatabaseJanitor(BaseDatabaseJanitor):
         try:
             if self.isolation_level is not None:
                 await conn.set_isolation_level(self.isolation_level)
-            await conn.set_autocommit(True)
+            await conn.set_autocommit(value=True)
             # We must not run a transaction since we create a database.
             async with conn.cursor() as cur:
                 yield cur

--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -7,7 +7,7 @@ from pytest_postgresql.executor import PostgreSQLExecutor
 from pytest_postgresql.executor_noop import NoopExecutor
 
 
-def load_schema(host: str, port: int, user: str, dbname: str, password: str | None, autocommit: bool) -> None:
+def load_schema(*, host: str, port: int, user: str, dbname: str, password: str | None, autocommit: bool) -> None:
     """Load schema into the database."""
     with psycopg.connect(host=host, port=port, user=user, dbname=dbname, password=password) as conn:
         conn.autocommit = autocommit
@@ -16,7 +16,7 @@ def load_schema(host: str, port: int, user: str, dbname: str, password: str | No
             conn.commit()
 
 
-def load_data(host: str, port: int, user: str, dbname: str, password: str | None, autocommit: bool) -> None:
+def load_data(*, host: str, port: int, user: str, dbname: str, password: str | None, autocommit: bool) -> None:
     """Load the first layer of data into the database."""
     with psycopg.connect(host=host, port=port, user=user, dbname=dbname, password=password) as conn:
         conn.autocommit = autocommit
@@ -26,7 +26,7 @@ def load_data(host: str, port: int, user: str, dbname: str, password: str | None
             conn.commit()
 
 
-def load_more_data(host: str, port: int, user: str, dbname: str, password: str | None, autocommit: bool) -> None:
+def load_more_data(*, host: str, port: int, user: str, dbname: str, password: str | None, autocommit: bool) -> None:
     """Load the second layer of data into the database."""
     with psycopg.connect(host=host, port=port, user=user, dbname=dbname, password=password) as conn:
         conn.autocommit = autocommit

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -117,7 +117,7 @@ async def test_cursor_skips_isolation_level_when_none_async() -> None:
             pass
 
     conn_mock.set_isolation_level.assert_not_called()
-    conn_mock.set_autocommit.assert_called_once_with(True)
+    conn_mock.set_autocommit.assert_called_once_with(value=True)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Unittest call_args.kwargs was introduced since python 3.8")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Options after the database name in PostgreSQL factories and executors must now be supplied as keyword arguments.
  * Update integrations that pass these options positionally.

* **Bug Fixes**
  * Improved asynchronous cursor configuration by using the correct autocommit argument handling.

* **Chores**
  * Enabled additional linting checks to detect potentially confusing boolean positional arguments and improve code consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->