### PR TITLE
Enable PT ruff rulesets - closes #1397

### DIFF
--- a/newsfragments/1397.misc.1.rst
+++ b/newsfragments/1397.misc.1.rst
@@ -1,0 +1,2 @@
+``postgresql_proc`` now tears down through a fixture ``yield`` instead of ``request.addfinalizer``.
+Consuming it as a pytest fixture is unaffected.

--- a/newsfragments/1397.misc.rst
+++ b/newsfragments/1397.misc.rst
@@ -1,0 +1,2 @@
+Enabled Ruff's `PT <https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt>`_ rules
+to keep pytest usage consistent across the plugin and its test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = [
     "I",   # isort
     "D",   # pydocstyle
     "FBT", # flake8-boolean-trap
+    "PT",  # flake8-pytest-style
 ]
 
 [tool.pyproject-fmt]

--- a/pytest_postgresql/config.py
+++ b/pytest_postgresql/config.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import pytest
 from _pytest._py.path import LocalPath
-from pytest import FixtureRequest
 
 
 @dataclass(frozen=True)
@@ -29,7 +29,7 @@ class PostgreSQLConfig:
     drop_test_database: bool
 
 
-def get_config(request: FixtureRequest) -> PostgreSQLConfig:
+def get_config(request: pytest.FixtureRequest) -> PostgreSQLConfig:
     """Return a PostgreSQLConfig instance with configuration options."""
 
     def get_postgresql_option(option: str) -> Any:

--- a/pytest_postgresql/factories/client.py
+++ b/pytest_postgresql/factories/client.py
@@ -22,7 +22,6 @@ from typing import AsyncIterator, Callable, Iterator, cast
 import psycopg
 import pytest
 from psycopg import AsyncConnection, Connection
-from pytest import FixtureRequest
 
 from pytest_postgresql._asyncio_compat import mark_postgresql_async_fixture, supports_loop_factories
 from pytest_postgresql.config import get_config
@@ -37,11 +36,11 @@ except ImportError:
 pytest_asyncio = _pytest_asyncio
 
 
-def _postgresql_async_unavailable_stub() -> Callable[[FixtureRequest], AsyncIterator[AsyncConnection]]:
+def _postgresql_async_unavailable_stub() -> Callable[[pytest.FixtureRequest], AsyncIterator[AsyncConnection]]:
     """Return a sync fixture stub that raises when pytest-asyncio is missing or too old."""
 
     @pytest.fixture
-    def postgresql_async_stub(request: FixtureRequest) -> None:
+    def postgresql_async_stub(request: pytest.FixtureRequest) -> None:
         """Sync stub that raises ImportError when pytest-asyncio is absent or too old."""
         raise ImportError(
             "pytest-asyncio >= 1.4 is required for async fixtures. "
@@ -50,7 +49,7 @@ def _postgresql_async_unavailable_stub() -> Callable[[FixtureRequest], AsyncIter
 
     mark_postgresql_async_fixture(postgresql_async_stub)
     return cast(
-        Callable[[FixtureRequest], AsyncIterator[AsyncConnection]],
+        Callable[[pytest.FixtureRequest], AsyncIterator[AsyncConnection]],
         postgresql_async_stub,
     )
 
@@ -59,7 +58,7 @@ def postgresql(
     process_fixture_name: str,
     dbname: str | None = None,
     isolation_level: "psycopg.IsolationLevel | None" = None,
-) -> Callable[[FixtureRequest], Iterator[Connection]]:
+) -> Callable[[pytest.FixtureRequest], Iterator[Connection]]:
     """Return connection fixture factory for PostgreSQL.
 
     :param process_fixture_name: name of the process fixture
@@ -70,7 +69,7 @@ def postgresql(
     """
 
     @pytest.fixture
-    def postgresql_factory(request: FixtureRequest) -> Iterator[Connection]:
+    def postgresql_factory(request: pytest.FixtureRequest) -> Iterator[Connection]:
         """Fixture connection factory for PostgreSQL.
 
         :param request: fixture request object
@@ -120,7 +119,7 @@ def postgresql_async(
     process_fixture_name: str,
     dbname: str | None = None,
     isolation_level: "psycopg.IsolationLevel | None" = None,
-) -> Callable[[FixtureRequest], AsyncIterator[AsyncConnection]]:
+) -> Callable[[pytest.FixtureRequest], AsyncIterator[AsyncConnection]]:
     """Return async connection fixture factory for PostgreSQL.
 
     Requires ``pytest-asyncio`` >= 1.4 (install via ``pip install pytest-postgresql[async]``).
@@ -135,7 +134,7 @@ def postgresql_async(
         return _postgresql_async_unavailable_stub()
 
     @pytest_asyncio.fixture
-    async def postgresql_async_factory(request: FixtureRequest) -> AsyncIterator[AsyncConnection]:
+    async def postgresql_async_factory(request: pytest.FixtureRequest) -> AsyncIterator[AsyncConnection]:
         """Async connection fixture factory for PostgreSQL.
 
         :param request: fixture request object
@@ -180,6 +179,6 @@ def postgresql_async(
 
     mark_postgresql_async_fixture(postgresql_async_factory)
     return cast(
-        Callable[[FixtureRequest], AsyncIterator[AsyncConnection]],
+        Callable[[pytest.FixtureRequest], AsyncIterator[AsyncConnection]],
         postgresql_async_factory,
     )

--- a/pytest_postgresql/factories/noprocess.py
+++ b/pytest_postgresql/factories/noprocess.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from typing import Callable, Iterator
 
 import pytest
-from pytest import FixtureRequest
 
 from pytest_postgresql.config import get_config
 from pytest_postgresql.executors import NoopExecutor
@@ -49,7 +48,7 @@ def postgresql_noproc(
     load: list[Callable | str | Path] | None = None,
     load_autocommit: bool | None = None,
     depends_on: str | None = None,
-) -> Callable[[FixtureRequest], Iterator[NoopExecutor]]:
+) -> Callable[[pytest.FixtureRequest], Iterator[NoopExecutor]]:
     """Postgresql noprocess factory.
 
     :param host: hostname
@@ -72,7 +71,7 @@ def postgresql_noproc(
     """
 
     @pytest.fixture(scope="session")
-    def postgresql_noproc_fixture(request: FixtureRequest) -> Iterator[NoopExecutor]:
+    def postgresql_noproc_fixture(request: pytest.FixtureRequest) -> Iterator[NoopExecutor]:
         """Noop Process fixture for PostgreSQL.
 
         :param request: fixture request object

--- a/pytest_postgresql/factories/process.py
+++ b/pytest_postgresql/factories/process.py
@@ -23,12 +23,11 @@ import os.path
 import platform
 import tempfile
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Iterator
 
 import port_for
 import pytest
 from port_for import PortForException, get_port
-from pytest import FixtureRequest, TempPathFactory
 
 from pytest_postgresql.config import PostgreSQLConfig, get_config
 from pytest_postgresql.executors import PostgreSQLExecutor
@@ -81,7 +80,7 @@ def postgresql_proc(
     postgres_options: str | None = None,
     load: list[Callable | str | Path] | None = None,
     load_autocommit: bool | None = None,
-) -> Callable[[FixtureRequest, TempPathFactory], PostgreSQLExecutor]:
+) -> Callable[[pytest.FixtureRequest, pytest.TempPathFactory], Iterator[PostgreSQLExecutor]]:
     """Postgresql process factory.
 
     :param executable: path to postgresql_ctl
@@ -108,7 +107,10 @@ def postgresql_proc(
     """
 
     @pytest.fixture(scope="session")
-    def postgresql_proc_fixture(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> PostgreSQLExecutor:
+    def postgresql_proc_fixture(
+        request: pytest.FixtureRequest,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> Iterator[PostgreSQLExecutor]:
         """Process fixture for PostgreSQL.
 
         :param request: fixture request object
@@ -221,16 +223,9 @@ def postgresql_proc(
             for load_element in pg_load:
                 janitor.load(load_element)
 
-            def cleanup() -> None:
-                try:
-                    janitor.drop()
-                finally:
-                    _cleanup_executor_resources()
-
-            request.addfinalizer(cleanup)
-            return postgresql_executor
-        except Exception:
+            yield postgresql_executor
+            janitor.drop()
+        finally:
             _cleanup_executor_resources()
-            raise
 
     return postgresql_proc_fixture

--- a/tests/examples/test_assert_load_autocommit_is_true.py
+++ b/tests/examples/test_assert_load_autocommit_is_true.py
@@ -3,12 +3,12 @@
 That shows that it is not the default (False), and that we parsed it as a bool.
 """
 
-from pytest import FixtureRequest
+import pytest
 
 from pytest_postgresql.config import get_config
 
 
-def test_assert_load_autocommit_is_true(request: FixtureRequest) -> None:
+def test_assert_load_autocommit_is_true(request: pytest.FixtureRequest) -> None:
     """Asserts that load_autocommit is True."""
     config = get_config(request)
     assert config.load_autocommit is True

--- a/tests/examples/test_assert_port_search_count_is_ten.py
+++ b/tests/examples/test_assert_port_search_count_is_ten.py
@@ -3,12 +3,12 @@
 That shows that it is not the default (5), and that we parsed it as an integer.
 """
 
-from pytest import FixtureRequest
+import pytest
 
 from pytest_postgresql.config import get_config
 
 
-def test_assert_port_search_count_is_ten(request: FixtureRequest) -> None:
+def test_assert_port_search_count_is_ten(request: pytest.FixtureRequest) -> None:
     """Asserts that port_search_count is 10."""
     config = get_config(request)
     assert config.port_search_count == 10

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,12 +9,12 @@ from pytest_postgresql.config import detect_paths
 
 
 @pytest.mark.parametrize(
-    "path, want",
-    (
+    ("path", "want"),
+    [
         ("test.sql", Path("test.sql")),
         ("load.function", "load.function"),
         (LocalPath("test.sql"), Path("test.sql").absolute()),  # type: ignore[no-untyped-call]
-    ),
+    ],
 )
 def test_detect_paths(path: str | LocalPath, want: Path | str) -> None:
     """Check the correctness of detect_paths function."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -6,7 +6,7 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import psycopg
@@ -14,7 +14,6 @@ import pytest
 from packaging.version import parse
 from port_for import PortForException, get_port
 from psycopg import Connection
-from pytest import FixtureRequest
 
 import pytest_postgresql.factories.process as process
 from pytest_postgresql.config import get_config
@@ -85,7 +84,7 @@ class PatchedPostgreSQLExecutor(PostgreSQLExecutor):
         return parse("8.9")
 
 
-def test_unsupported_version(request: FixtureRequest) -> None:
+def test_unsupported_version(request: pytest.FixtureRequest) -> None:
     """Check that the error gets raised on unsupported postgres version."""
     config = get_config(request)
     port = get_port(config.port)
@@ -240,9 +239,9 @@ async def test_postgresql_async_client_closes_on_pre_yield_failure() -> None:
 
 
 @pytest.mark.xdist_group(name="executor_no_xdist_guard")
-@pytest.mark.parametrize("locale", ("en_US.UTF-8", "de_DE.UTF-8", "nl_NO.UTF-8"))
+@pytest.mark.parametrize("locale", ["en_US.UTF-8", "de_DE.UTF-8", "nl_NO.UTF-8"])
 def test_executor_init_with_password(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path_factory: pytest.TempPathFactory,
     locale: str,
@@ -269,7 +268,7 @@ def test_executor_init_with_password(
 
 
 def test_executor_init_bad_tmp_path(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     r"""Test init with \ and space chars in the path."""
@@ -310,7 +309,7 @@ def test_executor_init_bad_tmp_path(
     ["Windows", "Linux", "Darwin", "FreeBSD"],
 )
 def test_executor_platform_template_selection(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     platform_name: str,
 ) -> None:
@@ -351,7 +350,7 @@ def test_executor_platform_template_selection(
 
 
 def test_executor_with_special_chars_in_all_paths(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     """Test executor with special characters in multiple paths simultaneously.
@@ -473,7 +472,7 @@ async def test_custom_async_isolation_level(postgres_async_isolation_level: psyc
 @contextmanager
 def _isolated_port_basetemp(
     tmp_path_factory: pytest.TempPathFactory,
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path: Path,
 ) -> Iterator[Path]:
     """Patch session basetemp to a per-test directory for port-lock sentinel files."""
@@ -487,7 +486,7 @@ def _isolated_port_basetemp(
 
 
 def test_postgresql_proc_removes_port_lock_on_teardown(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     tmp_path: Path,
 ) -> None:
@@ -514,15 +513,12 @@ def test_postgresql_proc_removes_port_lock_on_teardown(
         janitor_mock.init = MagicMock()
         janitor_mock.drop = MagicMock()
 
-        finalizers: list[Callable[[], None]] = []
-
         with (
             patch("pytest_postgresql.factories.process._pg_exe", return_value="/usr/bin/pg_ctl"),
             patch("pytest_postgresql.factories.process._pg_port", return_value=pg_port),
             patch("pytest_postgresql.factories.process.PostgreSQLExecutor", return_value=executor_mock),
             patch("pytest_postgresql.factories.process.DatabaseJanitor", return_value=janitor_mock),
             patch("pytest_postgresql.factories.process.get_config") as get_config_mock,
-            patch.object(request, "addfinalizer", side_effect=finalizers.append),
         ):
             config_mock = MagicMock()
             config_mock.dbname = "tests"
@@ -531,17 +527,17 @@ def test_postgresql_proc_removes_port_lock_on_teardown(
             config_mock.port_search_count = 5
             get_config_mock.return_value = config_mock
 
-            raw_func(request, tmp_path_factory)
+            generator = raw_func(request, tmp_path_factory)
+            next(generator)
             port_file = port_path / f"postgresql-{pg_port}.port"
             assert port_file.exists()
-            for finalizer in finalizers:
-                finalizer()
+            next(generator, None)
 
         assert not port_file.exists()
 
 
 def test_postgresql_proc_removes_port_lock_on_setup_failure(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     tmp_path: Path,
 ) -> None:
@@ -567,14 +563,14 @@ def test_postgresql_proc_removes_port_lock_on_setup_failure(
             get_config_mock.return_value = config_mock
 
             with pytest.raises(OSError, match="setup failed"):
-                raw_func(request, tmp_path_factory)
+                next(raw_func(request, tmp_path_factory))
 
         port_file = port_path / f"postgresql-{pg_port}.port"
         assert not port_file.exists()
 
 
 def test_postgresql_proc_stops_executor_on_setup_failure_after_start(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     tmp_path: Path,
 ) -> None:
@@ -618,7 +614,7 @@ def test_postgresql_proc_stops_executor_on_setup_failure_after_start(
             get_config_mock.return_value = config_mock
 
             with pytest.raises(RuntimeError, match="init failed"):
-                raw_func(request, tmp_path_factory)
+                next(raw_func(request, tmp_path_factory))
 
         executor_mock.stop.assert_called_once()
         executor_mock.clean_directory.assert_called_once()
@@ -627,7 +623,7 @@ def test_postgresql_proc_stops_executor_on_setup_failure_after_start(
 
 
 def test_postgresql_proc_cleanup_stops_executor_when_drop_fails(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     tmp_path: Path,
 ) -> None:
@@ -654,15 +650,12 @@ def test_postgresql_proc_cleanup_stops_executor_when_drop_fails(
         janitor_mock.init = MagicMock()
         janitor_mock.drop = MagicMock(side_effect=RuntimeError("drop failed"))
 
-        finalizers: list[Callable[[], None]] = []
-
         with (
             patch("pytest_postgresql.factories.process._pg_exe", return_value="/usr/bin/pg_ctl"),
             patch("pytest_postgresql.factories.process._pg_port", return_value=pg_port),
             patch("pytest_postgresql.factories.process.PostgreSQLExecutor", return_value=executor_mock),
             patch("pytest_postgresql.factories.process.DatabaseJanitor", return_value=janitor_mock),
             patch("pytest_postgresql.factories.process.get_config") as get_config_mock,
-            patch.object(request, "addfinalizer", side_effect=finalizers.append),
         ):
             config_mock = MagicMock()
             config_mock.dbname = "tests"
@@ -671,19 +664,19 @@ def test_postgresql_proc_cleanup_stops_executor_when_drop_fails(
             config_mock.port_search_count = 5
             get_config_mock.return_value = config_mock
 
-            raw_func(request, tmp_path_factory)
+            generator = raw_func(request, tmp_path_factory)
+            next(generator)
             port_file = port_path / f"postgresql-{pg_port}.port"
             assert port_file.exists()
             with pytest.raises(RuntimeError, match="drop failed"):
-                for finalizer in finalizers:
-                    finalizer()
+                next(generator, None)
 
         executor_mock.stop.assert_called_once()
         assert not port_file.exists()
 
 
 def test_postgresql_proc_port_lock_safe_on_pg_port_failure(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     tmp_path: Path,
 ) -> None:
@@ -710,13 +703,13 @@ def test_postgresql_proc_port_lock_safe_on_pg_port_failure(
             get_config_mock.return_value = config_mock
 
             with pytest.raises(PortForException, match="no free ports"):
-                raw_func(request, tmp_path_factory)
+                next(raw_func(request, tmp_path_factory))
 
         assert set(port_path.glob("postgresql-*.port")) == existing_ports
 
 
 def test_postgresql_proc_preserves_foreign_port_lock_on_exhausted_retries(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
     tmp_path: Path,
 ) -> None:
@@ -753,7 +746,7 @@ def test_postgresql_proc_preserves_foreign_port_lock_on_exhausted_retries(
                 get_config_mock.return_value = config_mock
 
                 with pytest.raises(PortForException, match="Attempted"):
-                    raw_func(request, tmp_path_factory)
+                    next(raw_func(request, tmp_path_factory))
 
             for pg_port, foreign_lock in zip(pg_ports, foreign_locks, strict=True):
                 assert foreign_lock.exists()
@@ -765,7 +758,7 @@ def test_postgresql_proc_preserves_foreign_port_lock_on_exhausted_retries(
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
 def test_actual_postgresql_start_windows(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     """Test that PostgreSQL actually starts on Windows with the new template.
@@ -804,7 +797,7 @@ def test_actual_postgresql_start_windows(
     reason="Unix/Linux-specific test",
 )
 def test_actual_postgresql_start_unix(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     """Test that PostgreSQL actually starts on Unix/Linux with the new template.
@@ -840,7 +833,7 @@ def test_actual_postgresql_start_unix(
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Darwin/macOS-specific test")
 def test_actual_postgresql_start_darwin(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     """Test that PostgreSQL actually starts on Darwin/macOS with the new template.

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -20,7 +20,7 @@ VERSION = parse("10")
 TEST_PASSWORD = "some_password"  # noqa: S105
 
 
-@pytest.mark.parametrize("version", (VERSION, 10, "10"))
+@pytest.mark.parametrize("version", [VERSION, 10, "10"])
 def test_version_is_deprecated(version: Any) -> None:
     """Test that version is cast to Version object with a deprecation warning."""
     with pytest.warns(DeprecationWarning, match="version argument is deprecated"):
@@ -34,7 +34,7 @@ def test_version_is_optional() -> None:
     assert janitor.version is None
 
 
-@pytest.mark.parametrize("version", (VERSION, 10, "10"))
+@pytest.mark.parametrize("version", [VERSION, 10, "10"])
 @pytest.mark.asyncio
 async def test_version_is_deprecated_async(version: Any) -> None:
     """Async test that version is cast to Version object with a deprecation warning."""
@@ -176,7 +176,7 @@ async def test_cursor_skips_isolation_level_when_none_async() -> None:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Unittest call_args.kwargs was introduced since python 3.8")
-@pytest.mark.parametrize("load_database", ("tests.loader.load_database", "tests.loader:load_database"))
+@pytest.mark.parametrize("load_database", ["tests.loader.load_database", "tests.loader:load_database"])
 @patch("pytest_postgresql.janitor.psycopg.connect")
 def test_janitor_populate(connect_mock: MagicMock, load_database: str) -> None:
     """Test that the cursor requests the postgres database.
@@ -198,7 +198,7 @@ def test_janitor_populate(connect_mock: MagicMock, load_database: str) -> None:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Unittest call_args.kwargs was introduced since python 3.8")
-@pytest.mark.parametrize("load_database", ("tests.loader.load_database", "tests.loader:load_database"))
+@pytest.mark.parametrize("load_database", ["tests.loader.load_database", "tests.loader:load_database"])
 @patch("tests.loader.psycopg.connect")
 @pytest.mark.asyncio
 async def test_janitor_populate_async(connect_mock: MagicMock, load_database: str) -> None:

--- a/tests/test_pg_exe.py
+++ b/tests/test_pg_exe.py
@@ -129,12 +129,12 @@ def test_client_only_install_raises_early(tmp_path: Path, config: PostgreSQLConf
 
 @pytest.mark.parametrize(
     "error",
-    (
+    [
         FileNotFoundError("pg_config"),
         PermissionError("pg_config"),
         subprocess.CalledProcessError(1, "pg_config"),
         subprocess.TimeoutExpired("pg_config", _pg.PG_CONFIG_TIMEOUT),
-    ),
+    ],
 )
 def test_broken_pg_config_surfaces_as_executable_missing(config: PostgreSQLConfig, error: Exception) -> None:
     """A missing, unusable, hanging or failing pg_config is reported as a missing executable.

--- a/tests/test_plugin_asyncio.py
+++ b/tests/test_plugin_asyncio.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest import Pytester
 
 import pytest_postgresql
 import pytest_postgresql.plugin as plugin_module
@@ -26,7 +25,7 @@ from pytest_postgresql.plugin import (
 
 
 @pytest.fixture
-def pointed_pytester(pytester: Pytester) -> Pytester:
+def pointed_pytester(pytester: pytest.Pytester) -> pytest.Pytester:
     """Pre-configured pytester fixture."""
     pytest_postgresql_path = Path(pytest_postgresql.__file__)
     root_path = pytest_postgresql_path.parent.parent
@@ -187,7 +186,7 @@ def test_item_uses_postgresql_async_fixture_detects_non_suffix_name() -> None:
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows postgresql_async E2E")
 def test_postgresql_async_windows_subprocess_smoke(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
 ) -> None:
     """postgresql_async works in a subprocess on Windows without manual loop configuration."""
     pointed_pytester.copy_example("test_postgresql_async_windows_smoke.py")

--- a/tests/test_postgres_options_plugin.py
+++ b/tests/test_postgres_options_plugin.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
-from pytest import Pytester
 
 import pytest_postgresql
 from pytest_postgresql.executors import PostgreSQLExecutor
@@ -15,7 +14,7 @@ from tests.loader import load_database
 
 
 @pytest.fixture
-def pointed_pytester(pytester: Pytester) -> Pytester:
+def pointed_pytester(pytester: pytest.Pytester) -> pytest.Pytester:
     """Pre-configured pytester fixture."""
     pytest_postgresql_path = Path(pytest_postgresql.__file__)
     root_path = pytest_postgresql_path.parent.parent
@@ -23,14 +22,14 @@ def pointed_pytester(pytester: Pytester) -> Pytester:
     return pytester
 
 
-def test_postgres_options_config_in_cli(pointed_pytester: Pytester) -> None:
+def test_postgres_options_config_in_cli(pointed_pytester: pytest.Pytester) -> None:
     """Check that command line arguments are honored."""
     pointed_pytester.copy_example("test_postgres_options.py")
     ret = pointed_pytester.runpytest("--postgresql-postgres-options", "-N 16", "test_postgres_options.py")
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_options_config_in_ini(pointed_pytester: Pytester) -> None:
+def test_postgres_options_config_in_ini(pointed_pytester: pytest.Pytester) -> None:
     """Check that pytest.ini arguments are honored."""
     pointed_pytester.copy_example("test_postgres_options.py")
     pointed_pytester.makefile(".ini", pytest="[pytest]\npostgresql_postgres_options = -N 16\n")
@@ -38,7 +37,7 @@ def test_postgres_options_config_in_ini(pointed_pytester: Pytester) -> None:
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_loader_in_cli(pointed_pytester: Pytester) -> None:
+def test_postgres_loader_in_cli(pointed_pytester: pytest.Pytester) -> None:
     """Check that command line arguments are honored."""
     pointed_pytester.copy_example("test_load.py")
     test_sql_path = pointed_pytester.copy_example("test.sql")
@@ -46,7 +45,7 @@ def test_postgres_loader_in_cli(pointed_pytester: Pytester) -> None:
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_loader_in_ini(pointed_pytester: Pytester) -> None:
+def test_postgres_loader_in_ini(pointed_pytester: pytest.Pytester) -> None:
     """Check that pytest.ini arguments are honored for load."""
     pointed_pytester.copy_example("test_load.py")
     test_sql_path = pointed_pytester.copy_example("test.sql")
@@ -58,14 +57,14 @@ def test_postgres_loader_in_ini(pointed_pytester: Pytester) -> None:
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_load_autocommit_in_cli(pointed_pytester: Pytester) -> None:
+def test_postgres_load_autocommit_in_cli(pointed_pytester: pytest.Pytester) -> None:
     """Check that the --postgresql-load-autocommit command line flag is honored."""
     pointed_pytester.copy_example("test_assert_load_autocommit_is_true.py")
     ret = pointed_pytester.runpytest("--postgresql-load-autocommit", "test_assert_load_autocommit_is_true.py")
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_load_autocommit_in_ini(pointed_pytester: Pytester) -> None:
+def test_postgres_load_autocommit_in_ini(pointed_pytester: pytest.Pytester) -> None:
     """Check that pytest.ini postgresql_load_autocommit is honored and parsed as a bool."""
     pointed_pytester.copy_example("test_assert_load_autocommit_is_true.py")
     pointed_pytester.makefile(".ini", pytest="[pytest]\npostgresql_load_autocommit = True\n")
@@ -73,14 +72,14 @@ def test_postgres_load_autocommit_in_ini(pointed_pytester: Pytester) -> None:
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_port_search_count_in_cli_is_int(pointed_pytester: Pytester) -> None:
+def test_postgres_port_search_count_in_cli_is_int(pointed_pytester: pytest.Pytester) -> None:
     """Check that the --postgresql-port-search-count command line argument is parsed as an int."""
     pointed_pytester.copy_example("test_assert_port_search_count_is_ten.py")
     ret = pointed_pytester.runpytest("--postgresql-port-search-count", "10", "test_assert_port_search_count_is_ten.py")
     ret.assert_outcomes(passed=1)
 
 
-def test_postgres_port_search_count_in_ini_is_int(pointed_pytester: Pytester) -> None:
+def test_postgres_port_search_count_in_ini_is_int(pointed_pytester: pytest.Pytester) -> None:
     """Check that pytest.ini arguments are honored for load."""
     pointed_pytester.copy_example("test_assert_port_search_count_is_ten.py")
     pointed_pytester.makefile(".ini", pytest="[pytest]\npostgresql_port_search_count = 10\n")
@@ -108,7 +107,7 @@ def maintenance_dbname(postgresql_proc_to_override: PostgreSQLExecutor) -> Itera
 
 def test_postgres_maintenance_dbname_in_cli(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
     maintenance_dbname: str,
 ) -> None:
     """Check that noproc fixtures work off a maintenance database other than postgres."""
@@ -125,7 +124,7 @@ def test_postgres_maintenance_dbname_in_cli(
 
 def test_postgres_maintenance_dbname_in_ini(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
     maintenance_dbname: str,
 ) -> None:
     """Check that pytest.ini postgresql_maintenance_dbname is honored."""
@@ -145,7 +144,7 @@ def test_postgres_maintenance_dbname_in_ini(
 
 def test_postgres_maintenance_dbname_is_used(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
 ) -> None:
     """Check the maintenance database is the one connected to, and not just accepted.
 
@@ -164,7 +163,7 @@ def test_postgres_maintenance_dbname_is_used(
 
 def _run_drop_test_database_case(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
     example_filename: str,
 ) -> None:
     dbname = xdistify_dbname("override")
@@ -222,7 +221,7 @@ def _run_drop_test_database_case(
 
 def test_postgres_drop_test_database(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
 ) -> None:
     """Check that the database is dropped on both process and client level if argument is passed.
 
@@ -245,7 +244,7 @@ def test_postgres_drop_test_database(
 
 def test_postgres_drop_test_database_async(
     postgresql_proc_to_override: PostgreSQLExecutor,
-    pointed_pytester: Pytester,
+    pointed_pytester: pytest.Pytester,
 ) -> None:
     """Check that async client fixture drops the database when --postgresql-drop-test-database is set.
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,15 +6,15 @@ from pytest_postgresql.executors import PostgreSQLExecutor
 
 
 @pytest.mark.parametrize(
-    "ctl_input, version",
-    (
+    ("ctl_input", "version"),
+    [
         ("pg_ctl (PostgreSQL) 10.18", "10.18"),
         ("pg_ctl (PostgreSQL) 11.13", "11.13"),
         ("pg_ctl (PostgreSQL) 12.8", "12.8"),
         ("pg_ctl (PostgreSQL) 13.4", "13.4"),
         ("pg_ctl (PostgreSQL) 14.0", "14.0"),
         ("pg_ctl (PostgreSQL) 16devel", "16"),
-    ),
+    ],
 )
 def test_versions(ctl_input: str, version: str) -> None:
     """Check correctness of the version regexp."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL process fixture teardown, ensuring resources are cleaned up reliably after fixture use.
  - Preserved existing fixture behaviour and consumption patterns.

- **Code Quality**
  - Enabled pytest-specific linting checks.
  - Standardised pytest type annotations and parameterised test formatting.

- **Tests**
  - Updated fixture and teardown tests to reflect the improved generator-based lifecycle.
  - Maintained coverage for PostgreSQL configuration, options, janitor behaviour and asynchronous scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->