### PR TITLE
Migrate tests to be based on 'uv-pytest-coverage' - closes #1424

### DIFF
--- a/.github/workflows/dockerised-postgres.yml
+++ b/.github/workflows/dockerised-postgres.yml
@@ -56,15 +56,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run test noproc fixture on docker
-        id: run_docker_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+        uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.docker -m pytest -n 0 --max-worker-restart 0 -k docker --postgresql-host=localhost --postgresql-port 5433 --postgresql-password=postgres
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.docker"}'
-      - name: Combine and export docker coverage
-        if: ${{ always() && (steps.run_docker_tests.conclusion == 'success' || steps.run_docker_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -n 0 --max-worker-restart 0 -k docker --postgresql-host=localhost --postgresql-port 5433 --postgresql-password=postgres
           data-file: .coverage.docker
           output-file: coverage-docker.xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/oldest-postgres.yml
+++ b/.github/workflows/oldest-postgres.yml
@@ -34,6 +34,7 @@ jobs:
       OS: ${{ inputs.os }}
       PYTHON: ${{ matrix.python-version }}
       POSTGRES: ${{ inputs.postgresql }}
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -63,28 +64,15 @@ jobs:
         uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
         with:
           command: pip install -r oldest/requirements.txt
-      - name: Run tests without xdist
-        id: run_serial_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+      - uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.serial -m pytest -c pyproject.oldest.toml -svv -p no:xdist --postgresql-exec="/usr/lib/postgresql/${{ inputs.postgresql }}/bin/pg_ctl" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
-      - name: Combine and export serial coverage
-        if: ${{ always() && (steps.run_serial_tests.conclusion == 'success' || steps.run_serial_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -c pyproject.oldest.toml -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
           data-file: .coverage.serial
           output-file: coverage-serial.xml
-      - name: Run xdist test
-        id: run_xdist_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+      - uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.xdist -m pytest -n auto -c pyproject.oldest.toml --dist loadgroup --max-worker-restart 0 --postgresql-exec="/usr/lib/postgresql/${{ inputs.postgresql }}/bin/pg_ctl" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.xdist"}'
-      - name: Combine and export xdist coverage
-        if: ${{ always() && (steps.run_xdist_tests.conclusion == 'success' || steps.run_xdist_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -n auto -c pyproject.oldest.toml --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          coverage-config: .coveragerc
           data-file: .coverage.xdist
           output-file: coverage-xdist.xml
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/single-postgres-windows.yml
+++ b/.github/workflows/single-postgres-windows.yml
@@ -46,28 +46,15 @@ jobs:
       - uses: ./.github/actions/detect-pg-ctl
         with:
           postgresql-version: ${{ inputs.postgresql }}
-      - name: Run test
-        id: run_serial_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+      - uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.serial -m pytest -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
-      - name: Combine and export serial coverage
-        if: ${{ always() && (steps.run_serial_tests.conclusion == 'success' || steps.run_serial_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
           data-file: .coverage.serial
           output-file: coverage-serial.xml
-      - name: Run xdist test
-        id: run_xdist_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+      - uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.xdist -m pytest -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.xdist"}'
-      - name: Combine and export xdist coverage
-        if: ${{ always() && (steps.run_xdist_tests.conclusion == 'success' || steps.run_xdist_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          coverage-config: .coveragerc
           data-file: .coverage.xdist
           output-file: coverage-xdist.xml
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/single-postgres.yml
+++ b/.github/workflows/single-postgres.yml
@@ -77,28 +77,15 @@ jobs:
       - name: install libpq
         if: ${{ contains(matrix.python-version, 'pypy') && runner.os == 'Linux' }}
         run: sudo apt install libpq5
-      - name: Run test
-        id: run_serial_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+      - uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.serial -m pytest -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
-      - name: Combine and export serial coverage
-        if: ${{ always() && (steps.run_serial_tests.conclusion == 'success' || steps.run_serial_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
           data-file: .coverage.serial
           output-file: coverage-serial.xml
-      - name: Run xdist test
-        id: run_xdist_tests
-        uses: fizyk/actions-reuse/.github/actions/uv-run@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
+      - uses: fizyk/actions-reuse/.github/actions/uv-pytest-coverage@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
         with:
-          command: python -m coverage run --data-file=.coverage.xdist -m pytest -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.xdist"}'
-      - name: Combine and export xdist coverage
-        if: ${{ always() && (steps.run_xdist_tests.conclusion == 'success' || steps.run_xdist_tests.conclusion == 'failure') }}
-        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@42b61e053c1d70a61deb42b323c1a2229e2e7fe0 # v5.5.0
-        with:
+          pytest-opts: -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          coverage-config: .coveragerc
           data-file: .coverage.xdist
           output-file: coverage-xdist.xml
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/newsfragments/1424.misc.rst
+++ b/newsfragments/1424.misc.rst
@@ -1,0 +1,1 @@
+Migrate tests to be based on `actions-reuse` new composite action `uv-pytest-coverage`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,11 @@ dev = [
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
     "pytest-xdist==3.8.0",
-    "tbump==6.11.0",
     "towncrier==25.8.0",
     "types-aiofiles==25.1.0.20260518",
+]
+release = [
+    "tbump==6.11.0",
 ]
 
 [tool.uv.build-backend]

--- a/uv.lock
+++ b/uv.lock
@@ -757,9 +757,11 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
-    { name = "tbump" },
     { name = "towncrier" },
     { name = "types-aiofiles" },
+]
+release = [
+    { name = "tbump" },
 ]
 
 [package.metadata]
@@ -788,10 +790,10 @@ dev = [
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
-    { name = "tbump", specifier = "==6.11.0" },
     { name = "towncrier", specifier = "==25.8.0" },
     { name = "types-aiofiles", specifier = "==25.1.0.20260518" },
 ]
+release = [{ name = "tbump", specifier = "==6.11.0" }]
 
 [[package]]
 name = "pytest-xdist"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated test workflow to use the reusable test and coverage action for both serial and parallel test runs.
  - Simplified coverage reporting and removed redundant workflow steps.

- **Documentation**
  - Added a release note documenting the migration to the updated test coverage workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->